### PR TITLE
feat: Enable polling of schedules

### DIFF
--- a/app.js
+++ b/app.js
@@ -15,6 +15,8 @@ const {
 require('./routes/api/schedule');
 require('./routes/api/simuldial');
 
+const { setDevSchedule, setProdSchedule } = require('./routes/api/schedule');
+
 const port = process.env.PORT || 80;
 
 const onListen = () =>
@@ -22,9 +24,17 @@ const onListen = () =>
     moment().tz('America/New_York').format(),
     `Server is running on port ${port}`,
   );
-const startUp = (languagesToPhones) => {
+const startUp = async (languagesToPhones) => {
   saveShiftNumbers(languagesToPhones);
+  await setDevSchedule();
+  await setProdSchedule();
   app.listen(port, onListen);
+
+  // event loop, we want these things to happen at a slow poll
+  setInterval(() => {
+    setDevSchedule();
+    setProdSchedule();
+  }, process.env.AIRTABLE_DELAY);
 };
 
 app.get('/', (req, res) => {

--- a/routes/api/schedule.js
+++ b/routes/api/schedule.js
@@ -2,10 +2,20 @@ const dotenv = require('dotenv');
 const axios = require('axios');
 const app = require('../../server');
 
+const DEV_SCHEDULE = 'devSchedule';
+const PROD_SCHEDULE = 'prodSchedule';
+
 if (process.env.NODE_ENV !== 'production') {
   dotenv.config(); // load the local .env file
 }
 
+/**
+ * Transforms the schedule retrieved from airbase RESTful api into
+ * the format that the consumer of the route expects
+ * @author Aaron Young <hi@aaronyoung.io>
+ * @param {Object} airbaseSchedule - Schedule returned from airbase's api
+ * @return {Object} - This represents a transformed schedule object
+ */
 const transformSchedule = (airbaseSchedule) => {
   const scheduleRecords = airbaseSchedule.records;
   const resultRecords = [];
@@ -24,25 +34,36 @@ const transformSchedule = (airbaseSchedule) => {
   return resultRecords;
 };
 
+/**
+ * Generates a function that queries airtable for data from the 'General Hours'
+ * table of the given base
+ * @author Aaron Young <hi@aaronyoung.io>
+ * @param {String} base - ID of the base we are generating a query function for
+ * @return {Function} - This function will always query the given base
+ */
+
 const getScheduleFromBase = (base) => {
-  const delay = parseInt(process.env.AIRTABLE_DELAY);
-  let schedule;
-  let lastRetrieved;
   const config = {
-    headers: { Authorization: `Bearer ${process.env.AIRTABLE_API_KEY}` },
+    headers: {
+      Authorization: `Bearer ${process.env.AIRTABLE_API_KEY}`,
+    },
   };
+
+  /**
+   * A function that will actually do the query for the base
+   * @author Aaron Young <hi@aaronyoung.io>
+   * @return {Promise} - this will resolve into a transformed schedule object
+   */
   return async () => {
-    if (!lastRetrieved || Date.now() - lastRetrieved > delay) {
-      try {
-        const response = await axios.get(
-          `https://api.airtable.com/v0/${base}/General%20Hours`,
-          config,
-        );
-        schedule = transformSchedule(response.data);
-      } catch (err) {
-        console.error(err);
-      }
-      lastRetrieved = Date.now();
+    let schedule;
+    try {
+      const response = await axios.get(
+        `https://api.airtable.com/v0/${base}/General%20Hours`,
+        config,
+      );
+      schedule = transformSchedule(response.data);
+    } catch (err) {
+      console.error(err);
     }
     return schedule;
   };
@@ -53,18 +74,65 @@ const getProdSchedule = getScheduleFromBase(
   process.env.AIRTABLE_PROD_PHONE_BASE,
 );
 
-app.get('/api/schedule/development', async (_req, res) => {
-  const schedule = await getDevSchedule();
-  res.status(200).json(schedule);
-});
+/**
+ * sets within express the development schedule
+ * @author Aaron Young <hi@aaronyoung.io>
+ * @param {Function} getSchedule - defaults to a function that when
+ * invoked returns a schedule object
+ * @return {void}
+ */
+const setDevSchedule = async (getSchedule = getDevSchedule) => {
+  const schedule = await getSchedule();
+  app.set(DEV_SCHEDULE, schedule);
+};
 
-app.get('/api/schedule/production', async (_req, res) => {
-  const schedule = await getProdSchedule();
-  res.status(200).json(schedule);
-});
+/**
+ * sets within express the production schedule
+ * @author Aaron Young <hi@aaronyoung.io>
+ * @param {Function} getSchedule - defaults to a function that when
+ * invoked returns a schedule object
+ * @return {void}
+ */
+const setProdSchedule = async (getSchedule = getProdSchedule) => {
+  const schedule = await getSchedule();
+  app.set(PROD_SCHEDULE, schedule);
+};
 
-// exporting for tests
+/**
+ * An express route function that matches the required express signature
+ * This will respond with a development schedule
+ * @author Aaron Young <hi@aaronyoung.io>
+ * @param {Object} _req - an express request object
+ * @param {Object} res - an express response object
+ * @return {void}
+ */
+const getDevelopment = async (_req, res) => {
+  const schedule = app.get(DEV_SCHEDULE);
+  res.status(200).json(schedule);
+};
+
+app.get('/api/schedule/development', getDevelopment);
+
+/**
+ * An express route function that matches the required express signature
+ * This will respond with a production schedule
+ * @author Aaron Young <hi@aaronyoung.io>
+ * @param {Object} _req - an express request object
+ * @param {Object} res - an express response object
+ * @return {void}
+ */
+const getProduction = async (_req, res) => {
+  const schedule = app.get(PROD_SCHEDULE);
+  res.status(200).json(schedule);
+};
+
+app.get('/api/schedule/production', getProduction);
+
+// exporting for tests and startup and event loop
 module.exports = {
   transformSchedule,
   getScheduleFromBase,
+  getDevSchedule,
+  setDevSchedule,
+  setProdSchedule,
 };


### PR DESCRIPTION
We needed to remove airbase form the express request cycle.
This will allow for faster response rates.

We will now poll the schedule at a specified time instead.