### PR TITLE
feat: Update logging to log http req/res cycles

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: node app.js
+web: node src/app.js

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -12,4 +12,5 @@ module.exports = {
     workspaceSid: process.env.WORKSPACE_SID || 'bogusWorkspace',
   },
   hostName: process.env.HOST_NAME || 'someHostName',
+  isProduction: process.env.NODE_ENV === 'production',
 };

--- a/src/loaders/logger.js
+++ b/src/loaders/logger.js
@@ -1,8 +1,10 @@
 const pino = require('pino');
 const expressPino = require('express-pino-logger');
+const config = require('../config');
 
+const useLevel = config.isProduction ? 'info' : 'debug';
 const logger = pino({ level: process.env.LOG_LEVEL || 'info' });
-const expressLogger = expressPino({ logger, useLevel: 'debug' });
+const expressLogger = expressPino({ logger, useLevel });
 
 module.exports = {
   logger,


### PR DESCRIPTION
1. Increase logging
  Heroku now has a log collector for 7 days of retention
  Since we now have a logging tool, we can have more detailed logging.
  I'm enabling http request response cycles so we can see our performance
  and any activity.
2. Update Procfile as we relocated the entry point